### PR TITLE
Updated code to Gnome 3.36, comments and small fixes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,4 @@
+'use strict';
 const Meta = imports.gi.Meta;
 
 /* This has been tested with both static and dynamic workspaces.  It
@@ -11,50 +12,86 @@ const Meta = imports.gi.Meta;
  *  (don't) skip first desktop
  */
 function check(act) {
-  const win = act.meta_window;
-  const workspacemanager = win.get_display().get_workspace_manager();
-  if (win.window_type !== Meta.WindowType.NORMAL)
-    return;
-  if (win.get_maximized() !== Meta.MaximizeFlags.BOTH)
-    return;
-  w = win.get_workspace().list_windows()
-    .filter(w => w !== win && !w.is_always_on_all_workspaces());
-  if (w.length>= 1) {
+  const metaWindow = act.meta_window;
+  const workspaceManager = metaWindow.get_display().get_workspace_manager();
+  // log('maximize-to-workspace check | window: ' + metaWindow.title);
+
+  // abort if it is not a normal window nor maximized
+  if (
+    metaWindow.window_type !== Meta.WindowType.NORMAL ||
+    metaWindow.get_maximized() !== Meta.MaximizeFlags.BOTH
+    ) {
+      return;
+    }
+
+  let windowList = metaWindow.get_workspace()
+    .list_windows()
+    .filter(w => w !== metaWindow && !w.is_on_all_workspaces());
+  
+  // continue only if exists any other window in the current workspace
+  if (windowList && windowList.length > 0) {
     // put on last workspace if all else fails (OO)
-    let lastworkspace = workspacemanager.get_n_workspaces()-1
+    let lastWorkspace = workspaceManager.get_n_workspaces() - 1;
+    if (lastWorkspace < 1) {
+      lastWorkspace = 1;
+    }
+      
     // always start with the second workspace (OO)
-    if (lastworkspace<1) lastworkspace=1
-    let wc;
-    let emptyworkspace;
-    for (emptyworkspace=1 ; emptyworkspace<lastworkspace; emptyworkspace++){
-      wc = workspacemanager.get_workspace_by_index(emptyworkspace).list_windows().filter(w=>!w.is_always_on_all_workspaces()).length
-      if (wc<1	) break;
+    let emptyWorkspace = 1;
+
+    // find the first workspace, or use last one if there is none
+    while (emptyWorkspace < lastWorkspace) {
+      windowList = workspaceManager.get_workspace_by_index(emptyWorkspace)
+        .list_windows()
+        .filter(w => !w.is_on_all_workspaces());
+      if (windowList.length < 1) {
+        break;
+        }
+      emptyWorkspace++;
     }
     // don't try to move it if we're already here (break recursion)
-    if (emptyworkspace == win.get_workspace().index())
+    if (emptyWorkspace == metaWindow.get_workspace().index()) {
       return;
-    win.change_workspace_by_index(emptyworkspace,1)
-    workspacemanager.get_workspace_by_index(emptyworkspace).activate(global.get_current_time())
+    }
+
+    // move windows and activate workspace
+    metaWindow.change_workspace_by_index(emptyWorkspace, false);
+    workspaceManager.get_workspace_by_index(emptyWorkspace)
+      .activate(global.get_current_time());
   }
 }
 
 const _handles = [];
 
 function enable() {
+  //log('maximize-to-workspace enable');
+
+  // when started, check all current windows
   global.get_window_actors().forEach(check);
+
+  // handle 'map' (new windows)
   _handles.push(global.window_manager.connect('map', (_, act) => check(act)));
+
+  // handle signal 'size-change'
   _handles.push(global.window_manager.connect('size-change', (_, act, change) => {
-    if (change === Meta.SizeChange.MAXIMIZE)
+    if (change === Meta.SizeChange.MAXIMIZE) {
       check(act);
+    }
   }));
+
+  // handle signal 'switch-workspace'
   _handles.push(global.window_manager.connect('switch-workspace', () => {
     const acts = global.get_window_actors()
       .filter(a => a.meta_window.has_focus());
-    if (acts.length)
+    if (acts.length) {
       check(acts[0]);
+    }
   }));
 }
 
 function disable() {
+  // log('maximize-to-workspace disable');
+
+  // disconnect from all signals
   _handles.splice(0).forEach(h => global.window_manager.disconnect(h));
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,15 @@
   "description": "Puts windows in a new workspace when maximized.",
   "uuid": "maximize-to-workspace@rliang.github.com",
   "url": "https://github.com/rliang/gnome-shell-extension-maximize-to-workspace",
-  "shell-version": ["3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26"]
+  "shell-version": [
+    "3.14",
+    "3.16",
+    "3.18",
+    "3.20",
+    "3.22",
+    "3.24",
+    "3.26",
+    "3.34",
+    "3.36"
+  ]
 }


### PR DESCRIPTION
- Code updated to Gnome 3.36 - Fixes #10 (tested on Gnome Shell 3.36.4, it should work on 3.34 as well but wasn't tested)
- Code refactored for better visualization
- Code commented 
- Fixed a bug related to windows "Always on Visible Workspace"